### PR TITLE
Port from WebKit to WebKit2

### DIFF
--- a/webviewer.py
+++ b/webviewer.py
@@ -22,9 +22,12 @@
 
 import logging
 
+import gi
 from gi.repository import Gtk, Gdk
 from gi.repository import GObject
-from gi.repository import WebKit
+gi.require_version('WebKit2', '4.0')
+from gi.repository import WebKit2
+
 
 
 class WebViewer(Gtk.ScrolledWindow):
@@ -32,7 +35,7 @@ class WebViewer(Gtk.ScrolledWindow):
     def __init__(self):
         Gtk.ScrolledWindow.__init__(self)
 
-        self.browser = WebKit.WebView()
+        self.browser = WebKit2.WebView()
         self.add(self.browser)
 
     def load_uri(self, uri):


### PR DESCRIPTION
### Explanation
Fixes #6. This PR ports from WebKit to WebKit2. 

### Reason
The WebKit API version 3.0 is deprecated and activities still using it throws a lot of PyGI errors

### Test result
No error related to the port from WebKit to WebKit2. 
```
tonadev@TDPC:~/Documents/Work/OpenSource/code_in/sugarlabs/maps-activity$ sugar-activity
/home/tonadev/Documents/Work/OpenSource/code_in/sugarlabs/maps-activity/map.py:29: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '3.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gtk
/home/tonadev/Documents/Work/OpenSource/code_in/sugarlabs/maps-activity/gplay.py:24: PyGIWarning: Gst was imported without specifying a version first. Use gi.require_version('Gst', '1.0') before import to ensure that the right version gets loaded.
  from gi.repository import Gst

(sugar-activity:3609): Gtk-WARNING **: 09:59:54.726: Theme parsing error: gtk-widgets.css:16:32: The style property GtkExpander:expander-size is deprecated and shouldn't be used anymore. It will be removed in a future version

(sugar-activity:3609): Gtk-WARNING **: 09:59:54.726: Theme parsing error: gtk-widgets.css:17:35: The style property GtkExpander:expander-spacing is deprecated and shouldn't be used anymore. It will be removed in a future version
1541174395.340619 WARNING root: icon_size is deprecated. Use pixel_size instead.
1541174395.342593 WARNING root: icon_size is deprecated. Use pixel_size instead.
1541174395.575985 ERROR root: Exception reading icon info: File contains no section headers.
file: /usr/share/icons/Adwaita/256x256/actions/edit-find.png, line: 1
'\x89PNG\r\n'
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/sugar3/graphics/icon.py", line 212, in _get_attach_points
    cp.readfp(config_file)
  File "/usr/lib/python2.7/ConfigParser.py", line 324, in readfp
    self._read(fp, filename)
  File "/usr/lib/python2.7/ConfigParser.py", line 512, in _read
    raise MissingSectionHeaderError(fpname, lineno, line)
MissingSectionHeaderError: File contains no section headers.
file: /usr/share/icons/Adwaita/256x256/actions/edit-find.png, line: 1
'\x89PNG\r\n'
127.0.0.1 - - [02/Nov/2018 09:59:55] "GET /comet.js?t=1541174395880 HTTP/1.1" 200 -
127.0.0.1 - - [02/Nov/2018 09:59:55] "GET /mediaQuery.js?s=21.527359999999994&w=-58.53096&n=74.92063999999999&e=36.39096 HTTP/1.1" 200 -

```