### PR TITLE
Fixing PyGiWarnings and deprecation warnings

### DIFF
--- a/gplay.py
+++ b/gplay.py
@@ -19,8 +19,9 @@
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 # look at jukeboxactivity.py
-
+import gi
 from gi.repository import Gtk
+gi.require_version('Gst', '1.0')
 from gi.repository import Gst
 from gi.repository import GLib
 

--- a/map.py
+++ b/map.py
@@ -25,9 +25,12 @@ import time
 import shutil
 import urllib
 import random
+import gi
 
-from gi.repository import Gtk
+gi.require_version('Gdk', '3.0')
 from gi.repository import Gdk
+gi.require_version('Gtk', '3.0')
+from gi.repository import Gtk
 from gi.repository import GObject
 from gi.repository import GLib
 from gi.repository import GdkPixbuf

--- a/tray.py
+++ b/tray.py
@@ -127,7 +127,7 @@ class _TrayScrollButton(Gtk.Button):
         self.set_relief(Gtk.ReliefStyle.NONE)
         self.set_size_request(style.GRID_CELL_SIZE, style.GRID_CELL_SIZE)
 
-        icon = Icon(icon_name=icon_name, icon_size=Gtk.IconSize.SMALL_TOOLBAR)
+        icon = Icon(icon_name=icon_name, pixel_size=Gtk.IconSize.SMALL_TOOLBAR)
         self.set_image(icon)
         icon.show()
 


### PR DESCRIPTION
On running the activity the console showed warnings for specifying
Gdk Gtk and Gst versions before importing, to ensure that the correct version
is used and icon_size deprecation warning.

Specifying versions before importing and changing icon_size to pixel_size.